### PR TITLE
Convert the string param to uppercase

### DIFF
--- a/functions/src/shared/validators/role.validator.ts
+++ b/functions/src/shared/validators/role.validator.ts
@@ -43,10 +43,10 @@ export const getRoleByIDValidationRules = (): ValidationChain[] => {
  * @returns CustomValidator
  * @description THIS IS A CUSTOM VALIDATION FUNCTION TO CHECK IF THE ROLE NAME IS ALREADY INTO THE DB
  */
-const isDuplicateRoleName: CustomValidator = (async (roleName) => {
+const isDuplicateRoleName: CustomValidator = (async (roleName: string) => {
   const roleController = new RoleController()
 
-  const response = await roleController.checkDuplicateRoleName(roleName)
+  const response = await roleController.checkDuplicateRoleName(roleName.toUpperCase())
   if (response) {
     return await Promise.reject(new Error(`The role name ${String(roleName)} already exists`))
   }


### PR DESCRIPTION
To fix the validation role name was necessary to convert the string param to uppercase.